### PR TITLE
Fix example inside README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ local path = myFinder:getPath(startx, starty, endx, endy)
 if path then
   print(('Path found! Length: %.2f'):format(path:getLength()))
 	for node, count in path:nodes() do
-	  print(('Step: %d - x: %d - y: %d'):format(count, node.x, node.y))
+	  print(('Step: %d - x: %d - y: %d'):format(count, node:getX(), node:getY()))
 	end
 end
 


### PR DESCRIPTION
Example inside README didn't work because node don't have x/y fields.
