### PR TITLE
Update Path class to allow different distances

### DIFF
--- a/jumper/core/path.lua
+++ b/jumper/core/path.lua
@@ -67,12 +67,15 @@ if (...) then
 	
   --- Evaluates the `path` length
   -- @class function
+  -- @tparam function heuristic Optional heuristic function for determining.
+  -- distance between nodes. Default: @{Heuristic.EUCLIDIAN}.
   -- @treturn number the `path` length
 	-- @usage local len = p:getLength()
-  function Path:getLength()
+  function Path:getLength(heuristic)
+    local heuristic = heuristic or Heuristic.EUCLIDIAN
     local len = 0
     for i = 2,#self._nodes do
-      len = len + Heuristic.EUCLIDIAN(self._nodes[i], self._nodes[i-1])
+      len = len + heuristic(self._nodes[i], self._nodes[i-1])
     end
     return len
   end

--- a/specs/path_specs.lua
+++ b/specs/path_specs.lua
@@ -43,6 +43,12 @@ context('Module Path', function()
 			p = Path()
 			for i = 1,10 do p._nodes[#p._nodes+1] = Node(i,i) end
 			assert_less_than(p:getLength()-9*math.sqrt(2),1e-6)			
+			
+			--Test with diagonal distance
+			local Heuristics = require ('jumper.core.heuristics')
+			p = Path()
+			for i = 1,10 do p._nodes[#p._nodes+1] = Node(i,i) end
+			assert_equal(p:getLength(Heuristics.DIAGONAL), 9)
 		end)
 		
 		test('Path:fill() interpolates a path', function()


### PR DESCRIPTION
Rather than always using the Euclidean distance metric to find the distance between nodes in the path, this commit adds an optional parameter to the `getPath` method to set the distance metric.