### PR TITLE
Remove invalid string escape.

### DIFF
--- a/specs/pathfinder_specs.lua
+++ b/specs/pathfinder_specs.lua
@@ -140,7 +140,7 @@ context('Module Pathfinder', function()
 			assert_equal(pf:getFinder(), 'ASTAR')
 		end)
 
-		test('Passing nil sets \'ASTAR\` as the finder if no previous finder was set, is \'ASTAR\'', function()
+		test('Passing nil sets \'ASTAR\' as the finder if no previous finder was set, is \'ASTAR\'', function()
 			local pf = PF(grid)
 			pf:setFinder()
 			assert_equal(pf:getFinder(), 'ASTAR')


### PR DESCRIPTION
The test uses an escaped backtick in a string literal. This works in lua 5.1, but causes an "invalid escape sequence" error in lua 5.3.