### PR TITLE
Rename EUCLIDIAN to EUCLIDEAN.

### DIFF
--- a/examples/customHeuristics.lua
+++ b/examples/customHeuristics.lua
@@ -15,8 +15,8 @@ local walkable = 0
 local grid = Grid(map)
 local myFinder = Pathfinder(grid, 'ASTAR', walkable)
 
--- Use Euclidian heuristic to evaluate distance
-myFinder:setHeuristic('EUCLIDIAN')
+-- Use Euclidean heuristic to evaluate distance
+myFinder:setHeuristic('EUCLIDEAN')
 myFinder:setHeuristic('DIAGONAL')
 myFinder:setHeuristic('MANHATTAN')
 

--- a/jumper/core/heuristics.lua
+++ b/jumper/core/heuristics.lua
@@ -10,7 +10,7 @@
 --     local function myHeuristic(nodeA, nodeB)
 --       -- function body
 --     end
--- Jumper features some built-in distance heuristics, namely `MANHATTAN`, `EUCLIDIAN`, `DIAGONAL`, `CARDINTCARD`.
+-- Jumper features some built-in distance heuristics, namely `MANHATTAN`, `EUCLIDEAN`, `DIAGONAL`, `CARDINTCARD`.
 -- You can also supply your own heuristic function, following the same template as above.
 
 
@@ -39,7 +39,7 @@ local Heuristics = {}
 		return (dx + dy) 
 	end
   
-  --- Euclidian distance.
+  --- Euclidean distance.
   -- <br/>Evaluates as <code>distance = squareRoot(dx*dx+dy*dy)</code>
   -- @class function
   -- @tparam node nodeA a node
@@ -47,15 +47,23 @@ local Heuristics = {}
   -- @treturn number the distance from __nodeA__ to __nodeB__
 	-- @usage
   -- -- First method
-  -- pathfinder:setHeuristic('EUCLIDIAN')
+  -- pathfinder:setHeuristic('EUCLIDEAN')
   -- -- Second method
   -- local Distance = require ('jumper.core.heuristics')
-  -- pathfinder:setHeuristic(Distance.EUCLIDIAN) 
-  function Heuristics.EUCLIDIAN(nodeA, nodeB)
+  -- pathfinder:setHeuristic(Distance.EUCLIDEAN) 
+  function Heuristics.EUCLIDEAN(nodeA, nodeB)
 		local dx = nodeA._x - nodeB._x
 		local dy = nodeA._y - nodeB._y
 		return sqrt(dx*dx+dy*dy) 
 	end
+
+  --- Euclidean distance.
+  -- <br/>Evaluates as <code>distance = squareRoot(dx*dx+dy*dy)</code>
+  -- @class function
+  -- @tparam node nodeA a node
+  -- @tparam node nodeB another node
+  -- @treturn number the distance from __nodeA__ to __nodeB__
+  Heuristics.EUCLIDIAN = Heuristics.EUCLIDEAN
   
   --- Diagonal distance.
   -- <br/>Evaluates as <code>distance = max(|dx|, abs|dy|)</code>

--- a/jumper/core/path.lua
+++ b/jumper/core/path.lua
@@ -72,7 +72,7 @@ if (...) then
   function Path:getLength()
     local len = 0
     for i = 2,#self._nodes do
-      len = len + Heuristic.EUCLIDIAN(self._nodes[i], self._nodes[i-1])
+      len = len + Heuristic.EUCLIDEAN(self._nodes[i], self._nodes[i-1])
     end
     return len
   end

--- a/jumper/search/astar.lua
+++ b/jumper/search/astar.lua
@@ -15,7 +15,7 @@ if (...) then
 
 	-- Updates G-cost
 	local function computeCost(node, neighbour, finder, clearance)
-		local mCost = Heuristics.EUCLIDIAN(neighbour, node)
+		local mCost = Heuristics.EUCLIDEAN(neighbour, node)
 		if node._g + mCost < neighbour._g then
 			neighbour._parent = node
 			neighbour._g = node._g + mCost

--- a/jumper/search/jps.lua
+++ b/jumper/search/jps.lua
@@ -219,7 +219,7 @@ end
       if jumpNode and not skip then
         -- Update the jump node and move it in the closed list if it wasn't there
         if not jumpNode._closed then			
-					local extraG = Heuristics.EUCLIDIAN(jumpNode, node)
+					local extraG = Heuristics.EUCLIDEAN(jumpNode, node)
 					local newG = node._g + extraG
 					if not jumpNode._opened or newG < jumpNode._g then
 						toClear[jumpNode] = true -- Records this node to reset its properties later.

--- a/jumper/search/thetastar.lua
+++ b/jumper/search/thetastar.lua
@@ -47,14 +47,14 @@ if (...) then
 	-- Theta star cost evaluation
 	local function computeCost(node, neighbour, finder, clearance)
 		local parent = node._parent or node
-		local mpCost = Heuristics.EUCLIDIAN(neighbour, parent)
+		local mpCost = Heuristics.EUCLIDEAN(neighbour, parent)
 		if lineOfSight(parent, neighbour, finder, clearance) then
 			if parent._g + mpCost < neighbour._g then
 				neighbour._parent = parent
 				neighbour._g = parent._g + mpCost
 			end
 		else
-			local mCost = Heuristics.EUCLIDIAN(neighbour, node)
+			local mCost = Heuristics.EUCLIDEAN(neighbour, node)
 			if node._g + mCost < neighbour._g then
 				neighbour._parent = node
 				neighbour._g = node._g + mCost

--- a/specs/heuristics_specs.lua
+++ b/specs/heuristics_specs.lua
@@ -28,24 +28,24 @@ context('Module Heuristics', function()
 		
   end)
 
-  context('EUCLIDIAN distance', function()
+  context('EUCLIDEAN distance', function()
 	
     test('is a function',function()
-			assert_type(H.EUCLIDIAN, 'function')
+			assert_type(H.EUCLIDEAN, 'function')
     end)
 	
 		test('evaluates as SQUAREROOT(dx*dx + dy*dy)', function()
-			assert_equal(H.EUCLIDIAN(Node(0,0), Node(0,0)), 0)
-			assert_equal(H.EUCLIDIAN(Node(0,0), Node(2,2)), math.sqrt(8))
-			assert_equal(H.EUCLIDIAN(Node(0,0), Node(5,3)), math.sqrt(34))		
+			assert_equal(H.EUCLIDEAN(Node(0,0), Node(0,0)), 0)
+			assert_equal(H.EUCLIDEAN(Node(0,0), Node(2,2)), math.sqrt(8))
+			assert_equal(H.EUCLIDEAN(Node(0,0), Node(5,3)), math.sqrt(34))		
 		end)
 		
 		test('calling the function with one arg raises an error', function()
-			assert_error(pcall(H.EUCLIDIAN,Node(0,0)))	
+			assert_error(pcall(H.EUCLIDEAN,Node(0,0)))	
 		end)	
 		
 		test('calling the function with no args raises an error', function()
-			assert_error(pcall(H.EUCLIDIAN))
+			assert_error(pcall(H.EUCLIDEAN))
 		end)		
 		
   end)


### PR DESCRIPTION
I've renamed all reference to the "Euclidian" distance to the "Euclidean", which is a much more common spelling. I've kept the "EUCLIDIAN" heuristic as an alias to "EUCLIDEAN".
