### PR TITLE
fix some functionality with clearances

### DIFF
--- a/jumper/search/astar.lua
+++ b/jumper/search/astar.lua
@@ -57,7 +57,7 @@ if (...) then
 			local node = openList:pop()
 			node._closed = true
 			if node == endNode then return node end
-			local neighbours = finder._grid:getNeighbours(node, finder._walkable, finder._allowDiagonal, finder._tunnel)
+			local neighbours = finder._grid:getNeighbours(node, finder._walkable, finder._allowDiagonal, finder._tunnel, clearance)
 			for i = 1,#neighbours do
 				local neighbour = neighbours[i]
 				if not neighbour._closed then

--- a/jumper/search/bfs.lua
+++ b/jumper/search/bfs.lua
@@ -5,7 +5,7 @@ if (...) then
   local t_remove = table.remove
 
   local function breadth_first_search(finder, openList, node, endNode, clearance, toClear)
-    local neighbours = finder._grid:getNeighbours(node, finder._walkable, finder._allowDiagonal, finder._tunnel)
+    local neighbours = finder._grid:getNeighbours(node, finder._walkable, finder._allowDiagonal, finder._tunnel, clearance)
     for i = 1,#neighbours do
       local neighbour = neighbours[i]
       if not neighbour._closed and not neighbour._opened then

--- a/jumper/search/dfs.lua
+++ b/jumper/search/dfs.lua
@@ -5,7 +5,7 @@ if (...) then
   local t_remove = table.remove
 
   local function depth_first_search(finder, openList, node, endNode, clearance, toClear)
-    local neighbours = finder._grid:getNeighbours(node, finder._walkable, finder._allowDiagonal, finder._tunnel)
+    local neighbours = finder._grid:getNeighbours(node, finder._walkable, finder._allowDiagonal, finder._tunnel, clearance)
     for i = 1,#neighbours do
       local neighbour = neighbours[i]
       if (not neighbour._closed and not neighbour._opened) then

--- a/jumper/search/thetastar.lua
+++ b/jumper/search/thetastar.lua
@@ -25,7 +25,7 @@ if (...) then
 		local sy = (y0 < y1) and 1 or -1		
 
 		while true do
-			if not finder._grid:isWalkableAt(x0, y0, finder._walkable, finder._tunnel, clearance) then 
+			if not finder._grid:isWalkableAt(x0, y0, finder._walkable, clearance) then
 				return false 
 			end
 			if x0 == x1 and y0 == y1 then


### PR DESCRIPTION
1. Some search algorithms that accepted `clearance` as a parameter did not pass it along to `getNeighbours`, resulting in neighbors being selected when they shouldn't have been.
2. The Theta-star algorithm did not handle clearance at all because it passed an extra incorrect parameter to `isWalkableAt`.